### PR TITLE
README: include k in the description.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,12 @@ export PATH="$PATH:$(pwd)"
 
 2. Create an FMS index from the masked superstring:
    ```
-   fmsi index -p ms.fa
+   fmsi index -p ms.fa -k 31
    ```
 
 3. Query the index from a given query FASTA file with k-mers:
    ```
-   fmsi query -p ms.fa -q query.fa -O
+   fmsi query -p ms.fa -q query.fa -k 31 -O
    ```
 
 #### Specific-case usage


### PR DESCRIPTION
Although FMSI can infer it from the mask convention, I included -k param in the readme for higher robustness.
This parameter is not mandatory as I think that it is a feature that might be handy, but it feels more safe to have it in the README that way.